### PR TITLE
Uses `strings.Builder` instead of []byte in `iter.ReadString`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/json-iterator/go
 
-go 1.12
+go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/type_tests/map_key_test.go
+++ b/type_tests/map_key_test.go
@@ -1,4 +1,4 @@
-// +build go1.15
+// +build go1.16
 // remove these tests temporarily until https://github.com/golang/go/issues/38105 and
 // https://github.com/golang/go/issues/38940 is fixed
 
@@ -27,8 +27,10 @@ func (k *stringKeyType) UnmarshalText(text []byte) error {
 	return nil
 }
 
-var _ encoding.TextMarshaler = stringKeyType("")
-var _ encoding.TextUnmarshaler = new(stringKeyType)
+var (
+	_ encoding.TextMarshaler   = stringKeyType("")
+	_ encoding.TextUnmarshaler = new(stringKeyType)
+)
 
 type structKeyType struct {
 	X string
@@ -43,5 +45,7 @@ func (k *structKeyType) UnmarshalText(text []byte) error {
 	return nil
 }
 
-var _ encoding.TextMarshaler = structKeyType{}
-var _ encoding.TextUnmarshaler = &structKeyType{}
+var (
+	_ encoding.TextMarshaler   = structKeyType{}
+	_ encoding.TextUnmarshaler = &structKeyType{}
+)


### PR DESCRIPTION
This is to avoid allocations, also fixes tests still not working with go1.15.

Signed-off-by: Cyril Tovena <cyril.tovena@gmail.com>